### PR TITLE
Return insertId in query result

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -125,6 +125,7 @@ class PlanetScaleConnection implements DatabaseConnection {
     }
 
     return {
+      insertId: results.insertId !== null && results.insertId.toString() !== '0' ? BigInt(results.insertId) : undefined,
       rows: results.rows as O[],
       numUpdatedOrDeletedRows: results.rowsAffected == null ? undefined : BigInt(results.rowsAffected),
     }


### PR DESCRIPTION
Adds support for returning the `insertId` on the query result. This is based off what kysely does in [its MySQL driver](https://github.com/koskimas/kysely/blob/d8c730b4ab866cab69baa174e156355ee7bb8004/src/dialect/mysql/mysql-driver.ts#L125-L130).