### PR TITLE
add `numAffectedRows` @ `PlanetScaleConnection.executeQuery`.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -124,10 +124,16 @@ class PlanetScaleConnection implements DatabaseConnection {
       throw (results as any).error
     }
 
+    const numAffectedRows = results.rowsAffected == null ? undefined : BigInt(results.rowsAffected)
+
     return {
       insertId: results.insertId !== null && results.insertId.toString() !== '0' ? BigInt(results.insertId) : undefined,
       rows: results.rows as O[],
-      numUpdatedOrDeletedRows: results.rowsAffected == null ? undefined : BigInt(results.rowsAffected),
+      // @ts-ignore replaces `QueryResult.numUpdatedOrDeletedRows` in kysely > 0.22
+      // following https://github.com/koskimas/kysely/pull/188
+      numAffectedRows,
+      // deprecated in kysely > 0.22, keep for backward compatibility.
+      numUpdatedOrDeletedRows: numAffectedRows,
     }
   }
 


### PR DESCRIPTION
aligns with koskimas/kysely#188 (not released yet)

`QueryResult.numUpdatedOrDeletedRows` is being deprecated in next `kysely` release, and will be removed in the future. It is being replaced with `QueryResult.numAffectedRows` for reasons discussed in linked pull request.