### PR TITLE
Update Kysely version

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@planetscale/database": "^1.19.0",
     "@tsconfig/node18": "^18.2.4",
     "@types/node": "^20.4.5",
-    "kysely": "^0.27.4",
+    "kysely": "^0.28.2",
     "prettier": "^3.3.3",
     "prettier-plugin-organize-imports": "^4.0.0",
     "prettier-plugin-pkg": "^0.18.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,8 +22,8 @@ importers:
         specifier: ^20.4.5
         version: 20.4.5
       kysely:
-        specifier: ^0.27.4
-        version: 0.27.4
+        specifier: ^0.28.2
+        version: 0.28.2
       prettier:
         specifier: ^3.3.3
         version: 3.3.3
@@ -503,9 +503,9 @@ packages:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
 
-  kysely@0.27.4:
-    resolution: {integrity: sha512-dyNKv2KRvYOQPLCAOCjjQuCk4YFd33BvGdf/o5bC7FiW+BB6snA81Zt+2wT9QDFzKqxKa5rrOmvlK/anehCcgA==}
-    engines: {node: '>=14.0.0'}
+  kysely@0.28.2:
+    resolution: {integrity: sha512-4YAVLoF0Sf0UTqlhgQMFU9iQECdah7n+13ANkiuVfRvlK+uI0Etbgd7bVP36dKlG+NXWbhGua8vnGt+sdhvT7A==}
+    engines: {node: '>=18.0.0'}
 
   lilconfig@3.1.2:
     resolution: {integrity: sha512-eop+wDAvpItUys0FWkHIKeC9ybYrTGbU41U5K7+bttZZeohvnY7M9dZ5kB21GNWiFT2q1OoPTvncPCgSOVO5ow==}
@@ -1146,7 +1146,7 @@ snapshots:
 
   joycon@3.1.1: {}
 
-  kysely@0.27.4: {}
+  kysely@0.28.2: {}
 
   lilconfig@3.1.2: {}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -155,8 +155,6 @@ class PlanetScaleConnection implements DatabaseConnection {
       // @ts-ignore replaces `QueryResult.numUpdatedOrDeletedRows` in kysely > 0.22
       // following https://github.com/koskimas/kysely/pull/188
       numAffectedRows,
-      // deprecated in kysely > 0.22, keep for backward compatibility.
-      numUpdatedOrDeletedRows: numAffectedRows,
     }
   }
 


### PR DESCRIPTION
In [the newset minor version](https://github.com/kysely-org/kysely/releases/tag/0.28.0) of Kysely, `QueryResult.numUpdatedOrDeletedRows` has been removed.
Kysely is now logging a warning about it:
> kysely: outdated driver/plugin detected! `QueryResult.numUpdatedOrDeletedRows` has been replaced with `QueryResult.numAffectedRows`.

This PR updates the Kysely version and removes `numUpdatedOrDeletedRows` from the return value (`QueryResult`) of the `execute` method.